### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0](https://github.com/ilya-epifanov/wikidesk/releases/tag/wikidesk-server-v0.1.0) - 2026-04-09
+
+### Other
+
+- Fix release-plz publish: add shared version requirement and changelog paths
+- Set up project for OSS publish
+- Rename project to wikidesk and restructure into workspace


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-server`: 0.1.0
* `wikidesk`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-server`

<blockquote>

## [0.1.0](https://github.com/ilya-epifanov/wikidesk/releases/tag/wikidesk-server-v0.1.0) - 2026-04-09

### Other

- Fix release-plz publish: add shared version requirement and changelog paths
- Set up project for OSS publish
- Rename project to wikidesk and restructure into workspace
</blockquote>

## `wikidesk`

<blockquote>

## [0.1.0](https://github.com/ilya-epifanov/wikidesk/releases/tag/wikidesk-server-v0.1.0) - 2026-04-09

### Other

- Fix release-plz publish: add shared version requirement and changelog paths
- Set up project for OSS publish
- Rename project to wikidesk and restructure into workspace
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).