### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.0...wikidesk-shared-v0.1.1) - 2026-04-09
+
+### Other
+
+- Publish wikidesk-shared to crates.io
+- Bump reqwest to 0.13 and sha2 to 0.11
+- Configure lockstep versioning and exclude shared crate from publishing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-shared"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,18 @@ members = ["server", "client", "shared"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ilya-epifanov/wikidesk"
 
+<<<<<<< Updated upstream
+=======
+[workspace.dependencies]
+wikidesk-shared = { path = "shared", version = "0.1.1" }
+
+>>>>>>> Stashed changes
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-shared`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `wikidesk-server`: 0.1.0 -> 0.1.1
* `wikidesk`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-shared`

<blockquote>

## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.0...wikidesk-shared-v0.1.1) - 2026-04-09

### Other

- Publish wikidesk-shared to crates.io
- Bump reqwest to 0.13 and sha2 to 0.11
- Configure lockstep versioning and exclude shared crate from publishing
</blockquote>

## `wikidesk-server`

<blockquote>

## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.0...wikidesk-shared-v0.1.1) - 2026-04-09

### Other

- Publish wikidesk-shared to crates.io
- Bump reqwest to 0.13 and sha2 to 0.11
- Configure lockstep versioning and exclude shared crate from publishing
</blockquote>

## `wikidesk`

<blockquote>

## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.0...wikidesk-shared-v0.1.1) - 2026-04-09

### Other

- Publish wikidesk-shared to crates.io
- Bump reqwest to 0.13 and sha2 to 0.11
- Configure lockstep versioning and exclude shared crate from publishing
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).