### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.1...v0.1.2) - 2026-04-10
+
+### Fixed
+
+- resolve hostnames in bind_address via ToSocketAddrs
+
 ## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.0...v0.1.1) - 2026-04-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2858,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-shared"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["server", "client", "shared"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ilya-epifanov/wikidesk"
 
 [workspace.dependencies]
-wikidesk-shared = { path = "shared", version = "0.1.1" }
+wikidesk-shared = { path = "shared", version = "0.1.2" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-shared`: 0.1.1 -> 0.1.2
* `wikidesk-server`: 0.1.1 -> 0.1.2
* `wikidesk`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-shared`

<blockquote>

## [0.1.1](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.0...v0.1.1) - 2026-04-10

### Fixed

- resolve hostnames in bind_address via ToSocketAddrs
</blockquote>

## `wikidesk-server`

<blockquote>

## [0.1.2](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.1...v0.1.2) - 2026-04-10

### Fixed

- resolve hostnames in bind_address via ToSocketAddrs
</blockquote>

## `wikidesk`

<blockquote>

## [0.1.2](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.1...v0.1.2) - 2026-04-10

### Fixed

- resolve hostnames in bind_address via ToSocketAddrs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).