### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.2...wikidesk-shared-v0.2.0) - 2026-07-02
+
+### Added
+
+- add agent setup discovery
+- support named wiki instances
+- *(server)* add pluggable runners with stream-json and ACP support
+
+### Other
+
+- Update wiki routing and local paths
+- deepen sync plan
+- deepen wiki sync and tree traversal
+- add TODO list with planned features
+- add see-also link to llmwiki-tooling
+
 ## [0.1.2](https://github.com/ilya-epifanov/wikidesk/compare/v0.1.1...v0.1.2) - 2026-04-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-server"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-shared"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["server", "client", "shared"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ilya-epifanov/wikidesk"
 
 [workspace.dependencies]
-wikidesk-shared = { path = "shared", version = "0.1.2" }
+wikidesk-shared = { path = "shared", version = "0.2.0" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-shared`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `wikidesk-server`: 0.1.2 -> 0.2.0
* `wikidesk`: 0.1.2 -> 0.2.0

### ⚠ `wikidesk-shared` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ResearchRequest.local_path in /tmp/.tmpdFFf9H/wikidesk/shared/src/lib.rs:12

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum wikidesk_shared::WalkError, previously in file /tmp/.tmpNadj8m/wikidesk-shared/src/lib.rs:45

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field wiki_path of struct ResearchRequest, previously in file /tmp/.tmpNadj8m/wikidesk-shared/src/lib.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-shared`

<blockquote>

## [0.2.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.2...wikidesk-shared-v0.2.0) - 2026-07-02

### Added

- add agent setup discovery
- support named wiki instances
- *(server)* add pluggable runners with stream-json and ACP support

### Other

- Update wiki routing and local paths
- deepen sync plan
- deepen wiki sync and tree traversal
- add TODO list with planned features
- add see-also link to llmwiki-tooling
</blockquote>

## `wikidesk-server`

<blockquote>

## [0.2.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.2...wikidesk-shared-v0.2.0) - 2026-07-02

### Added

- add agent setup discovery
- support named wiki instances
- *(server)* add pluggable runners with stream-json and ACP support

### Other

- Update wiki routing and local paths
- deepen sync plan
- deepen wiki sync and tree traversal
- add TODO list with planned features
- add see-also link to llmwiki-tooling
</blockquote>

## `wikidesk`

<blockquote>

## [0.2.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.2...wikidesk-shared-v0.2.0) - 2026-07-02

### Added

- add agent setup discovery
- support named wiki instances
- *(server)* add pluggable runners with stream-json and ACP support

### Other

- Update wiki routing and local paths
- deepen sync plan
- deepen wiki sync and tree traversal
- add TODO list with planned features
- add see-also link to llmwiki-tooling
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).