### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.2.0...wikidesk-shared-v0.3.0) - 2026-07-05
+
+### Added
+
+- add jj-backed research execution
+
+### Other
+
+- improve wikidesk operational logging
+- mark jj workflow done
+
 ## [0.2.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.1.2...wikidesk-shared-v0.2.0) - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-shared"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["server", "client", "shared"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ilya-epifanov/wikidesk"
 
 [workspace.dependencies]
-wikidesk-shared = { path = "shared", version = "0.2.0" }
+wikidesk-shared = { path = "shared", version = "0.3.0" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-shared`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `wikidesk-server`: 0.2.0 -> 0.3.0
* `wikidesk`: 0.2.0 -> 0.3.0

### ⚠ `wikidesk-shared` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum wikidesk_shared::WikiSyncError, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:195

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function wikidesk_shared::ensure_local_mirror_safe, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:375
  function wikidesk_shared::compute_sync, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:290
  function wikidesk_shared::snapshot_local_mirror, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:255
  function wikidesk_shared::walk_markdown_files, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:232
  function wikidesk_shared::apply_sync, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:327
  function wikidesk_shared::snapshot_dir, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:241
  function wikidesk_shared::walk_dir, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:223

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct wikidesk_shared::SyncRequest, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:104
  struct wikidesk_shared::SyncResponse, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:117
  struct wikidesk_shared::FileContent, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:123
  struct wikidesk_shared::WikiFile, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:188
  struct wikidesk_shared::SyncPlan, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:128
  struct wikidesk_shared::FileEntry, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:110
  struct wikidesk_shared::SyncSummary, previously in file /tmp/.tmpraKSe6/wikidesk-shared/src/lib.rs:176
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-shared`

<blockquote>

## [0.3.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.2.0...wikidesk-shared-v0.3.0) - 2026-07-05

### Added

- add jj-backed research execution

### Other

- improve wikidesk operational logging
- mark jj workflow done
</blockquote>

## `wikidesk-server`

<blockquote>

## [0.3.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.2.0...wikidesk-shared-v0.3.0) - 2026-07-05

### Added

- add jj-backed research execution

### Other

- improve wikidesk operational logging
- mark jj workflow done
</blockquote>

## `wikidesk`

<blockquote>

## [0.3.0](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.2.0...wikidesk-shared-v0.3.0) - 2026-07-05

### Added

- add jj-backed research execution

### Other

- improve wikidesk operational logging
- mark jj workflow done
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).