### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.3.2...wikidesk-shared-v0.3.3) - 2026-07-14
+
+### Added
+
+- run jj research concurrently
+
 ## [0.3.2](https://github.com/ilya-epifanov/wikidesk/compare/v0.3.0...v0.3.2) - 2026-07-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2954,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "wikidesk-shared"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "serde",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["server", "client", "shared"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ilya-epifanov/wikidesk"
 
 [workspace.dependencies]
-wikidesk-shared = { path = "shared", version = "0.3.2" }
+wikidesk-shared = { path = "shared", version = "0.3.3" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION



## 🤖 New release

* `wikidesk-shared`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `wikidesk-server`: 0.3.2 -> 0.3.3
* `wikidesk`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `wikidesk-shared`

<blockquote>

## [0.3.3](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.3.2...wikidesk-shared-v0.3.3) - 2026-07-14

### Added

- run jj research concurrently
</blockquote>

## `wikidesk-server`

<blockquote>

## [0.3.3](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.3.2...wikidesk-shared-v0.3.3) - 2026-07-14

### Added

- run jj research concurrently
</blockquote>

## `wikidesk`

<blockquote>

## [0.3.3](https://github.com/ilya-epifanov/wikidesk/compare/wikidesk-shared-v0.3.2...wikidesk-shared-v0.3.3) - 2026-07-14

### Added

- run jj research concurrently
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).